### PR TITLE
Update README: mention Australian state/territory flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The sub-regions currently covered are:
 - Canadian provinces and territories
 - Countries of England, Scotland, and Wales in Great Britain
 - The province Northern Ireland in Great Britain
+- Australia's states and its two self-governing internal territories
 
 The flags are downloaded from Wikipedia. When Wikipedia flags were copyrighted,
 we worked we Wikipedia editors to either relicense them, or drew / sourced and


### PR DESCRIPTION
"two self-governing internal territories" is a reference to Australian Capital Territory (ACT) and Northern Territory (NT). Australia also has external territories, which are not included in this as subdivisions of Australia since many of them have their own ISO 3166-1 codes; and also a non-self-governing internal territory (Jervis Bay Territory, JBT), which lacks an ISO 3166-2 code, and also lacks a flag.